### PR TITLE
Update simc tokenization rules

### DIFF
--- a/simc_support/game_data/SimcObject.py
+++ b/simc_support/game_data/SimcObject.py
@@ -18,7 +18,7 @@ class SimcObject(object):
         simc_name = self.full_name.lower()
         cleansers = (
             (" ", "_"),
-            ("-", "_"),
+            ("-", ""),
             ("'", ""),
             (":", ""),
             (",", ""),


### PR DESCRIPTION
While simc tokenizer is a bit more complicated then that (we essentially work off a whitelist, see https://github.com/simulationcraft/simc/blob/59cd3b4bc21663f400e4bac959afe814bbe5c12e/engine%2Futil%2Futil.cpp#L3011), the major thing that comes up in WoW names is dashes which the tokenizer removes.